### PR TITLE
Remove requirement for JAVA_HOME on install

### DIFF
--- a/Init.ps1
+++ b/Init.ps1
@@ -5,8 +5,6 @@ function Init-Posh-Sdk() {
     $ErrorActionPreference = 'Stop'
     $ProgressPreference = 'SilentlyContinue'
 
-    Check-JAVA-HOME
-
     # Check if $Global:PSDK_DIR is available, if not create it
     if ( !( Test-Path "$Global:PSDK_DIR\.meta" ) ) {
         New-Item -ItemType Directory "$Global:PSDK_DIR\.meta" | Out-Null


### PR DESCRIPTION
This will remove the unnecessary check for JAVA_HOME on the install. 

Usually I just set my JAVA_HOME to be an empty string when first setting up the pc, the installing sdkman and a java distribution, then setting JAVA_HOME again. 

This removes the annoying/confusing first step. 